### PR TITLE
Davidasix/data refresh on load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bragfeed.dev",
-  "version": "0.8.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bragfeed.dev",
-      "version": "0.8.0",
+      "version": "1.0.0",
       "dependencies": {
         "@auth/drizzle-adapter": "^1.7.4",
         "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -15,6 +15,7 @@
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
+        "@radix-ui/react-tooltip": "^1.2.8",
         "@stripe/stripe-js": "^7.3.0",
         "@tanstack/react-query": "^5.71.0",
         "@tanstack/react-query-devtools": "^5.71.0",
@@ -3121,6 +3122,356 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-rect": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1",
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/rect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.0.tgz",
@@ -3252,6 +3603,52 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
+    "@radix-ui/react-tooltip": "^1.2.8",
     "@stripe/stripe-js": "^7.3.0",
     "@tanstack/react-query": "^5.71.0",
     "@tanstack/react-query-devtools": "^5.71.0",

--- a/src/app/(product)/google-reviews/[id]/page.tsx
+++ b/src/app/(product)/google-reviews/[id]/page.tsx
@@ -18,6 +18,12 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { LoadingSpinner } from "@/components/ui/custom/loading-spinner";
 import { ReviewCard } from "../_components/review-card";
 import { StarRatingSelector } from "../_components/star-rating-selector";
@@ -94,7 +100,8 @@ export default function BusinessDetailsPage() {
     );
   }
 
-  const { business, reviews, available_reviews, last_refreshed } = businessQuery.data;
+  const { business, reviews, available_reviews, last_refreshed } =
+    businessQuery.data;
 
   return (
     <>
@@ -116,36 +123,58 @@ export default function BusinessDetailsPage() {
 
             {/* Business Stats */}
             {business.stats && (
-              <div className="flex justify-center gap-8 mb-6 flex-wrap">
-                <div className="text-center">
-                  <div className="text-3xl font-bold text-secondary">
-                    {business.stats.review_count || 0}
+              <TooltipProvider>
+                <div className="flex justify-center gap-8 mb-6 flex-wrap">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="text-center">
+                        <div className="text-3xl font-bold text-secondary">
+                          {business.stats.review_count || 0}
+                        </div>
+                        <div className="text-sm text-gray-600">
+                          Total Reviews
+                        </div>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Total number of reviews on Google for this business</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <div className="text-center">
+                    <div className="text-3xl font-bold text-yellow-500">
+                      {business.stats.review_score
+                        ? business.stats.review_score.toFixed(1)
+                        : "—"}
+                    </div>
+                    <div className="text-sm text-gray-600">Average Rating</div>
                   </div>
-                  <div className="text-sm text-gray-600">Total Reviews</div>
-                </div>
-                <div className="text-center">
-                  <div className="text-3xl font-bold text-yellow-500">
-                    {business.stats.review_score
-                      ? business.stats.review_score.toFixed(1)
-                      : "—"}
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <div className="text-center">
+                        <div className="text-3xl font-bold text-primary">
+                          {available_reviews || 0}
+                        </div>
+                        <div className="text-sm text-gray-600">
+                          Available Reviews
+                        </div>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>
+                        Number of reviews stored in Bragfeed&apos;s database
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <div className="text-center">
+                    <div className="text-3xl font-bold text-gray-700">
+                      {last_refreshed
+                        ? new Date(last_refreshed).toLocaleDateString()
+                        : "—"}
+                    </div>
+                    <div className="text-sm text-gray-600">Data Refreshed</div>
                   </div>
-                  <div className="text-sm text-gray-600">Average Rating</div>
                 </div>
-                <div className="text-center">
-                  <div className="text-3xl font-bold text-primary">
-                    {available_reviews || 0}
-                  </div>
-                  <div className="text-sm text-gray-600">Available Reviews</div>
-                </div>
-                <div className="text-center">
-                  <div className="text-3xl font-bold text-gray-700">
-                    {last_refreshed
-                      ? new Date(last_refreshed).toLocaleDateString()
-                      : "—"}
-                  </div>
-                  <div className="text-sm text-gray-600">Data Refreshed</div>
-                </div>
-              </div>
+              </TooltipProvider>
             )}
           </div>
         </div>

--- a/src/app/(product)/google-reviews/[id]/page.tsx
+++ b/src/app/(product)/google-reviews/[id]/page.tsx
@@ -94,7 +94,7 @@ export default function BusinessDetailsPage() {
     );
   }
 
-  const { business, reviews } = businessQuery.data;
+  const { business, reviews, available_reviews, last_refreshed } = businessQuery.data;
 
   return (
     <>
@@ -116,7 +116,7 @@ export default function BusinessDetailsPage() {
 
             {/* Business Stats */}
             {business.stats && (
-              <div className="flex justify-center gap-8 mb-6">
+              <div className="flex justify-center gap-8 mb-6 flex-wrap">
                 <div className="text-center">
                   <div className="text-3xl font-bold text-secondary">
                     {business.stats.review_count || 0}
@@ -130,6 +130,20 @@ export default function BusinessDetailsPage() {
                       : "—"}
                   </div>
                   <div className="text-sm text-gray-600">Average Rating</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-3xl font-bold text-primary">
+                    {available_reviews || 0}
+                  </div>
+                  <div className="text-sm text-gray-600">Available Reviews</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-3xl font-bold text-gray-700">
+                    {last_refreshed
+                      ? new Date(last_refreshed).toLocaleDateString()
+                      : "—"}
+                  </div>
+                  <div className="text-sm text-gray-600">Data Refreshed</div>
                 </div>
               </div>
             )}

--- a/src/app/(product)/google-reviews/[id]/page.tsx
+++ b/src/app/(product)/google-reviews/[id]/page.tsx
@@ -3,10 +3,12 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useParams, useSearchParams } from "next/navigation";
+import { RefreshCw } from "lucide-react";
 import { toast } from "sonner";
 
 import getBusinessDetailsSchema from "@/app/api/google/get-business-details/schema";
 import updateMinimumScoreSchema from "@/app/api/google/update-minimum-score/schema";
+import refreshBusinessDetailsSchema from "@/app/api/google/refresh-business-details/schema";
 import requests from "@/lib/requests";
 
 import { Button } from "@/components/ui/button";
@@ -69,6 +71,21 @@ export default function BusinessDetailsPage() {
     },
   });
 
+  const refreshBusinessDataMutation = useMutation({
+    mutationFn: async () => {
+      return requests.post(refreshBusinessDetailsSchema, { businessId });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["businessDetails", businessId],
+      });
+      toast.success("Data refreshed successfully!");
+    },
+    onError: () => {
+      toast.error("Failed to refresh business data");
+    },
+  });
+
   if (businessQuery.isLoading) {
     return (
       <section className="section section-padding">
@@ -108,7 +125,7 @@ export default function BusinessDetailsPage() {
       {/* Header Section */}
       <section className="section section-padding bg-gradient-to-b from-primary/10 to-white">
         <div className="content">
-          <div className="flex items-center gap-4 mb-6">
+          <div className="flex items-center justify-between gap-4 mb-6">
             <Button variant="default" asChild>
               <Link href="/dashboard">← Dashboard</Link>
             </Button>
@@ -193,11 +210,33 @@ export default function BusinessDetailsPage() {
               <TabsContent value="details" className="space-y-6">
                 <Card>
                   <CardHeader>
-                    <CardTitle>Review Filtering</CardTitle>
-                    <CardDescription>
-                      Set the minimum star rating for reviews to be returned by
-                      the API
-                    </CardDescription>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <CardTitle>Review Filtering</CardTitle>
+                        <CardDescription>
+                          Set the minimum star rating for reviews to be returned
+                          by the API
+                        </CardDescription>
+                      </div>
+                      <div className="flex flex-col items-end gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => refreshBusinessDataMutation.mutate()}
+                          disabled={refreshBusinessDataMutation.isPending}
+                          className="gap-2"
+                        >
+                          <RefreshCw
+                            className={`h-4 w-4 ${refreshBusinessDataMutation.isPending ? "animate-spin" : ""}`}
+                          />
+                          Refresh Data
+                        </Button>
+                        <p className="text-xs text-gray-500 max-w-xs text-right">
+                          Your data is also re-fetched during each API request
+                          so that your API calls always return fresh data.
+                        </p>
+                      </div>
+                    </div>
                   </CardHeader>
                   <CardContent>
                     <StarRatingSelector

--- a/src/app/api/google/get-business-details/schema.ts
+++ b/src/app/api/google/get-business-details/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { APISchema } from "@/schema/types";
+import { type APISchema, stringDate } from "@/schema/types";
 
 const schema = {
   url: "/api/google/get-business-details",
@@ -33,6 +33,8 @@ const schema = {
         comments: z.string().nullable(),
       }),
     ),
+    available_reviews: z.number().nullable(),
+    last_refreshed: stringDate.nullable(),
   }),
 } satisfies APISchema;
 

--- a/src/app/api/google/insert-new-business/route.ts
+++ b/src/app/api/google/insert-new-business/route.ts
@@ -57,7 +57,7 @@ export const POST: RequestHandler<NextRouteContext> = withAuth(
       await userHasOwnership(context.user_id, business.id, businesses);
 
       const insertedStats = await updateBusinessStats(business.id);
-      const insertedReviews = await updateBusinessReviews(business.id);
+      const insertedReviews = await updateBusinessReviews(business.id, 100);
       await recordEvent("update_reviews", context.user_id, {
         business_id: business.id,
       });

--- a/src/app/api/google/refresh-business-details/route.ts
+++ b/src/app/api/google/refresh-business-details/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+import { eq, and } from "drizzle-orm";
+
+import schema from "./schema";
+import { NextRouteContext, RequestHandler } from "@/middleware/types";
+import { withAuth } from "@/middleware/withAuth";
+import { withBody } from "@/middleware/withBody";
+
+import {
+  updateBusinessReviews,
+  updateBusinessStats,
+} from "@/lib/server/google/update";
+import { recordEvent } from "@/lib/server/events";
+import { userHasOwnership } from "@/lib/ownership";
+import { businesses } from "@/schema/schema";
+import { db } from "@/schema/db";
+
+/**
+ * This endpoint refreshes business data by fetching the latest reviews and stats from Google.
+ */
+export const POST: RequestHandler<NextRouteContext> = withAuth(
+  withBody(schema, async (_, context) => {
+    try {
+      const { businessId } = context.body;
+
+      // Verify the business exists and user has ownership
+      const [business] = await db
+        .select({ id: businesses.id })
+        .from(businesses)
+        .where(
+          and(
+            eq(businesses.id, businessId),
+            eq(businesses.user_id, context.user_id),
+          ),
+        )
+        .limit(1);
+
+      if (!business) {
+        return NextResponse.json(
+          { error: "Business not found" },
+          { status: 404 },
+        );
+      }
+
+      await userHasOwnership(context.user_id, businessId, businesses);
+
+      // Update stats and reviews
+      await updateBusinessStats(businessId);
+      await updateBusinessReviews(businessId, 100);
+
+      await recordEvent("update_reviews", context.user_id, {
+        business_id: businessId,
+      });
+
+      await recordEvent("update_stats", context.user_id, {
+        business_id: businessId,
+      });
+
+      const response = schema.response.parse({
+        success: true,
+      });
+
+      return NextResponse.json(response, { status: 200 });
+    } catch (error) {
+      console.error("Error refreshing business details:", error);
+      return NextResponse.json(
+        { error: "Internal Server Error" },
+        { status: 500 },
+      );
+    }
+  }),
+);

--- a/src/app/api/google/refresh-business-details/schema.ts
+++ b/src/app/api/google/refresh-business-details/schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import type { APISchema } from "@/schema/types";
+
+const schema = {
+  url: "/api/google/refresh-business-details",
+  request: z.object({
+    businessId: z.string().uuid(),
+  }),
+  response: z.object({
+    success: z.boolean(),
+  }),
+} satisfies APISchema;
+
+export default schema;

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/lib/server/google/update.ts
+++ b/src/lib/server/google/update.ts
@@ -52,9 +52,13 @@ export async function updateBusinessStats(business_id: string): Promise<{
  * This function will only insert new reviews that do not already exist in the database.
  *
  * @param { business_id } - The database business UUID to update.
+ * @param { reviewsToFetch } - The number of recent reviews to fetch from Google (default is 10).
  * @returns { Array } - An array of inserted reviews.
  */
-export async function updateBusinessReviews(business_id: string) {
+export async function updateBusinessReviews(
+  business_id: string,
+  reviewsToFetch = 10,
+) {
   const business = await db
     .select()
     .from(businesses)
@@ -68,7 +72,7 @@ export async function updateBusinessReviews(business_id: string) {
 
   // Get the google business class
   const googleReviews = new GoogleReviews(placeId);
-  const recentReviews = await googleReviews.getRecent();
+  const recentReviews = await googleReviews.getRecent(reviewsToFetch);
 
   // Get the existing reviews for the business which appear in the recentReviews array
   const existingReviews = await db


### PR DESCRIPTION
This PR adds a manual refresh button to the business details page and fixes a bug where the endpoint was returning duplicate rows when fetching stats. Also adds some UI polish like tooltips and displays more business info on the page.

- Added new `/api/google/refresh-business-details` endpoint to manually trigger a refetch of business data from Google
- Fixed bug in `get-business-details` where leftJoin with `business_stats` could return multiple rows - now uses `selectBusinessStats` helper
- Added tooltips to review cards showing full review text
- Display business address, review count, and rating on the business details page
- Changed default business insert to 100 on first load
- Made review count configurable in the update function